### PR TITLE
Trim config file '\n' for compatibility.

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gawwo/fake115-go/log"
 	"github.com/gawwo/fake115-go/utils"
 	"os"
+	"strings"
 )
 
 var showVersion bool
@@ -25,6 +26,7 @@ func init() {
 	// 确保cookie是否真的存在
 	if config.Cookie == "" {
 		cookie, _ := utils.ReadCookieFile()
+		cookie = strings.Trim(cookie, "\n")
 		config.Cookie = cookie
 	}
 }


### PR DESCRIPTION
删除读取cookie文件时多余的换行符
方便使用`echo 'cookie_str' > cookie.txt`